### PR TITLE
[Node v10] fs.readFile() and .appendFile() now need a callback

### DIFF
--- a/axe-reports.js
+++ b/axe-reports.js
@@ -549,7 +549,7 @@ exports.processResults = function (results, fileType, fileName, createNewReport)
                             }
 
                             outputRow = outputRow.replace(/(\r\n|\n|\r)/gm,'');
-                            fs.appendFile(fileName, outputRow + "\r", (err) => {
+                            fs.appendFile(fileName, outputRow + '\r', (err) => {
                               if (err) throw err;
                             });
                             outputRow = '';

--- a/axe-reports.js
+++ b/axe-reports.js
@@ -488,7 +488,9 @@ exports.processResults = function (results, fileType, fileName, createNewReport)
     if (createNewReport) {
         outputRow = ('URL' + delimiter + 'Volation Type' + delimiter + 'Impact' + delimiter + 'Help'
                     + delimiter + 'HTML Element' + delimiter + 'Messages' + delimiter +  'DOM Element\r');
-        fs.writeFile(fileName, outputRow);
+        fs.writeFile(fileName, outputRow, (err) => {
+            if (err) throw err;
+        });
         outputRow = '';
     }
 
@@ -547,7 +549,9 @@ exports.processResults = function (results, fileType, fileName, createNewReport)
                             }
 
                             outputRow = outputRow.replace(/(\r\n|\n|\r)/gm,'');
-                            fs.appendFile(fileName, outputRow + '\r');
+                            fs.appendFile(fileName, outputRow + "\r", (err) => {
+                              if (err) throw err;
+                            });
                             outputRow = '';
                         }
                     }


### PR DESCRIPTION
Hi and thanks for your useful work!

This PR solves the errors thrown when using `axe-reports` with node v10.x

From [fs.readFile](https://nodejs.org/api/fs.html#fs_fs_readfile_path_options_callback) documentation:

> fs.readFile(path[, options], callback) // ⇐ No brackets around callback parameter
> ◼️ History
>    v10.0.0 | The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.

and it does! (I use `node -v ⇒ v10.3.0`)